### PR TITLE
UTCT-2: Update Laravel Mix scripts to version 6 compatible.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
     },
     "scripts": {
         "dev": "npm run development",
-        "development": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --config=node_modules/laravel-mix/setup/webpack.config.js",
-        "watch": "npm run development -- --watch",
-        "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
+        "development": "mix",
+        "watch": "mix watch",
+        "hot": "mix watch --hot",
         "prod": "npm run production",
-        "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --config=node_modules/laravel-mix/setup/webpack.config.js"
+        "production": "mix --production"
     },
     "keywords": [],
     "author": "",


### PR DESCRIPTION
Signed-off-by: Chris Gilligan <chris-gilligan@utc.edu>

- https://laravel-mix.com/docs/6.0/upgrade