### PR TITLE
UTC-61: Fix errors caused by OCM entries.

### DIFF
--- a/config/child-theme-settings.php
+++ b/config/child-theme-settings.php
@@ -20,8 +20,8 @@ return [
 		'breadcrumb_archive'        => 1,
 		'breadcrumb_404'            => 0,
 		'breadcrumb_attachment'     => 0,
-		'content_archive'           => 'full',
-		'content_archive_limit'     => 130,
+		'content_archive'           => 'excerpts',
+		'content_archive_limit'     => 100,
 		'content_archive_thumbnail' => 1,
 		'entry_meta_after_content'  => '[post_categories before="' . __( 'Categories', 'utc' ) . ': "][post_tags before="' . __( 'Tags', 'utc' ) . ': "] [post_edit]',
 		'entry_meta_before_content' => '[post_author_posts_link before="' . __( '', 'utc' ) . '<br>"][post_date before="' . __( '', 'utc' ) . '<br>"] [post_comments before="' . __( '', 'utc' ) . '" zero="' . __( 'No comments yet', 'utc' ) . '"]',
@@ -31,6 +31,7 @@ return [
 		'show_featured_image_post'  => 1,
 		'show_featured_image_page'  => 1,
 		'site_layout'               => 'sidebar-content',
+		'utc_intro_paragraph_styling' => 1,
 	],
 	'posts_per_page'       => 5,
 ];

--- a/js/global.js
+++ b/js/global.js
@@ -219,8 +219,16 @@
       $('<h3 class="widgettitle widget-title">Section Menu</h3>').prependTo(this);
     }
   });
+/*****************Fix OEmbed issues that OCM makes frequently****************/
 
-  /****B/C Safari won't play nice with the Apply Now transitions, we're going to add the browser as a body class****/
+const bodyHasFirstParagraphTrue = document.body.classList.contains('first-paragraph-true');
+const entryContent = document.querySelector(".entry-content");
+
+$('.entry-content:has(iframe) p:first-child').addClass('first-child');
+$('.entry-content p:has(iframe)').parent().addClass('first-has-iframe');
+
+
+/****B/C Safari won't play nice with the Apply Now transitions, we're going to add the browser as a body class****/
   var BrowserDetect = {
       init: function() {
           this.browser = this.searchString(this.dataBrowser) || "Other";
@@ -326,6 +334,8 @@ if (bodyHasClass && sidebarHasMenu) {
     .appendChild(hamburgerMenu);
   hamburgerMenu.innerHTML = "&nbsp;";
 }
+
+
 
 
 

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  Author:       Bridget Hornsby
  Author URI:   https://www.utc.edu/
  Template:     genesis
- Version:      1.5.9.2
+ Version:      1.5.9.3
  License:      GNU General Public License v2 or later
  License URI:  http://www.gnu.org/licenses/gpl-2.0.html
  Tags:         light-only, left-sidebar, full-width, right-sidebar, responsive-layout, accessibility-ready, onboarding available
@@ -456,6 +456,9 @@ a.addtoany_share i, a.addtoany_share svg {
 .addtoany_list.a2a_kit_size_32 a:hover {
 	color:unset;
 	opacity:50%;
+}
+.home .addtoany_content, .frontpage .addtoany_content, .archive .addtoany_content, .category .addtoany_content, .tags .addtoany_content {
+  display:none!important;
 }
 #a2apage_dropdown {
   @apply -mt-5 ml-12 bg-white rounded-none p-4 border-0 shadow-utc w-16;
@@ -1390,7 +1393,11 @@ svg.utc-logo {
 }
 .image-featured-blog.image-alignleft,
 .image-featured-blog.image-alignright {
-  @apply mb-0 max-w-1/4;
+  @apply mb-0;
+  /*bc the contributors don't always use the feature image, but allow the first image to be grabbed, we must set fixed widths*/
+  min-width:175px;
+  max-width:175px;
+  width:175px;
 }
 .image-featured-blog.image-alignleft {
   @apply mr-6;
@@ -2119,8 +2126,11 @@ body.widgets-php .widget_nav_menu ul > li a {
 .archive-entry.post-image-alignright.post-image-featured-blog h2.entry-title {
   @apply text-2xl mb-3;
 }
-.single .content .entry-content > p:first-of-type {
-  @apply pb-0 border-0;
+.first-paragraph-true .entry-content > p:first-of-type, .first-paragraph-true .entry-content.first-has-iframe > p:nth-child(2) {
+  @apply pb-0 border-0 text-xl;
+}
+.first-paragraph-true .entry-content.first-has-iframe > p:nth-child(2) {
+  @apply mt-12;
 }
 .entry-comments-link {
   @apply pt-0 pb-4;
@@ -3040,7 +3050,7 @@ input[type="submit"]:focus {
   }
   .image-featured-blog.image-alignleft,
   .image-featured-blog.image-alignright {
-    @apply float-none ml-0 mr-0 max-w-none;
+    @apply float-none ml-0 mr-0 w-full max-w-none;
   }
   .archive-featured-image-wrap.image-zoom img {
     @apply m-0 w-full h-auto;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -102,7 +102,10 @@ module.exports = {
     extend: {},
   },
   fontSize: {
-    base: ['18px', '24px'],
+    sm: ['16px', '19px'],
+    base: ['18px', '22px'],
+    lg: ['21px', '24px'],
+    xl: ['27px', '30px'],
   },
   plugins: [],
 };


### PR DESCRIPTION
Five files are changed to fix the issues listed in #61 .

1. config/child-theme-settings.php
Made excerpts default to "excerpts", reduced word count to 100, and added functionality of first paragraph option from the child theme settings.

2. functions.php
Modified existing "Continue Reading" link function, added 2 functions for "excerpts" option in child theme to control the "Continue Reading" button and default WP elipses, added body class if the first paragraph option is true.

3. js/global.js
If the first paragraph option is true and the body class has been added, we need to check to see if the first paragraph contains an iframe.

4. style.css
Added the first paragraph styling whether its truly styling the first paragraph or technically the second paragraph when the first contains an iframe, removed the addtoany buttons that show when "excerpt" in the child theme settings is checked, and create a fixed size for the thumbnails on home page or archive pages regardless of whether the user uploads a feature image or uses a hero default in the feature image absence/

5. tailwind.config.js
Improve sizing leading of various tailwind text sizing.

**RESULTS**
![Screen Shot 2022-08-31 at 3 08 26 PM](https://user-images.githubusercontent.com/82905787/187762442-dcc329c7-91a2-4f61-9dbc-feee266d1406.png)

![Screen Shot 2022-08-31 at 3 08 44 PM](https://user-images.githubusercontent.com/82905787/187762469-5a447fa9-132d-49c7-84cf-d579e74765a9.png)

**IN CUSTOMIZATION:**

![Screen Shot 2022-08-31 at 2 04 20 PM](https://user-images.githubusercontent.com/82905787/187764136-304868d8-f9d8-48d7-9f95-68ebbeb9f20a.png)

![Screen Shot 2022-08-31 at 2 04 56 PM](https://user-images.githubusercontent.com/82905787/187764151-8338e4a5-2f4d-4efb-9ce1-023df59508ac.png)

