### PR TITLE
UTC-667: Fix H1 style in the search bar of the editor window.

### DIFF
--- a/dist/style.css
+++ b/dist/style.css
@@ -5,7 +5,7 @@
  Author:       Bridget Hornsby & Weston Gentry
  Author URI:   https://www.utc.edu/
  Template:     genesis
- Version:      2.0.5
+ Version:      2.0.6
  License:      GNU General Public License v2 or later
  License URI:  http://www.gnu.org/licenses/gpl-2.0.html
  Tags:         light-only, left-sidebar, full-width, right-sidebar, responsive-layout, accessibility-ready, onboarding available
@@ -25316,6 +25316,12 @@ h2:first-of-type {
 .comment-respond h3 small {
   font-size: 1.25rem;
   line-height: 1.75rem;
+}
+
+.editor-document-bar__title h1 {
+  font-family:unset;
+  padding-bottom:0;
+  border:none;
 }
 
 /* Objects

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  Author:       Bridget Hornsby & Weston Gentry
  Author URI:   https://www.utc.edu/
  Template:     genesis
- Version:      2.0.5
+ Version:      2.0.6
  License:      GNU General Public License v2 or later
  License URI:  http://www.gnu.org/licenses/gpl-2.0.html
  Tags:         light-only, left-sidebar, full-width, right-sidebar, responsive-layout, accessibility-ready, onboarding available
@@ -351,6 +351,7 @@ h1.entry-title,
 h1.archive-title {
   @apply text-6xl text-center w-full pb-6 border-b-8 border-utc-gold-500 font-medium mt-24 mb-16 mx-auto leading-tight;
 }
+
 .genesis-breadcrumbs-visible h1,
 .genesis-breadcrumbs-visible h1.entry-title,
 .genesis-breadcrumbs-visible h1.archive-title {
@@ -391,6 +392,11 @@ h2:first-of-type {
 }
 .comment-respond h3 small {
   @apply text-xl;
+}
+.editor-document-bar__title h1 {
+ font-family:unset;
+ padding-bottom:0;
+ border:none; 
 }
 /* Objects
   --------------------------------------------- */


### PR DESCRIPTION
Fixed: 

<img width="925" height="356" alt="Screenshot 2026-03-06 at 2 48 49 PM" src="https://github.com/user-attachments/assets/26388ee3-8501-4d4c-8cc9-faf03c85c077" />
